### PR TITLE
Replace deprecated selectors

### DIFF
--- a/keymaps/bug-report.cson
+++ b/keymaps/bug-report.cson
@@ -7,7 +7,7 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace':
+'atom-workspace':
   'ctrl-shift-alt-b': 'bug-report:open'
 '.title-input.native-key-bindings':
   'enter': 'core:confirm'

--- a/styles/bug-report.less
+++ b/styles/bug-report.less
@@ -1,6 +1,6 @@
 @import "ui-variables";
 
-.workspace .bug-report-panel {
+atom-workspace .bug-report-panel {
     position:   relative;
     width:      100%;
     padding-top: 8px;


### PR DESCRIPTION
Replace `.workspace` selectors in favor of `atom-workspace` inside `keymaps/bug-report.cson` and `styles/bug-report.less`